### PR TITLE
refactor(dom): use phf_map to define static map instead of oncelock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "aria_query"
 version = "0.1.0"
 dependencies = [
  "insta",
+ "phf",
 ]
 
 [[package]]
@@ -60,6 +61,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +119,21 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "serde"
@@ -102,6 +160,12 @@ name = "similar"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.60"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+phf = { version = "0.11", features = ["macros"] }
 
 [dev-dependencies]
 insta = { version = "1.34.0", features = ["json"] }

--- a/src/dom/mod.rs
+++ b/src/dom/mod.rs
@@ -1,170 +1,160 @@
+use phf::{phf_ordered_map, OrderedMap};
 use std::collections::HashMap;
-use std::sync::OnceLock;
 
-static DOM_ELEMENTS: OnceLock<HashMap<&'static str, bool>> = OnceLock::new();
+static DOM_ELEMENTS: OrderedMap<&'static str, bool> = phf_ordered_map! {
+    "a" => false,
+    "abbr" => false,
+    "acronym" => false,
+    "address" => false,
+    "applet" => false,
+    "area" => false,
+    "article" => false,
+    "aside" => false,
+    "audio" => false,
+    "b" => false,
+    "base" => true,
+    "bdi" => false,
+    "bdo" => false,
+    "big" => false,
+    "blink" => false,
+    "blockquote" => false,
+    "body" => false,
+    "br" => false,
+    "button" => false,
+    "canvas" => false,
+    "caption" => false,
+    "center" => false,
+    "cite" => false,
+    "code" => false,
+    "col" => true,
+    "colgroup" => true,
+    "content" => false,
+    "data" => false,
+    "datalist" => false,
+    "dd" => false,
+    "del" => false,
+    "details" => false,
+    "dfn" => false,
+    "dialog" => false,
+    "dir" => false,
+    "div" => false,
+    "dl" => false,
+    "dt" => false,
+    "em" => false,
+    "embed" => false,
+    "fieldset" => false,
+    "figcaption" => false,
+    "figure" => false,
+    "font" => false,
+    "footer" => false,
+    "form" => false,
+    "frame" => false,
+    "frameset" => false,
+    "h1" => false,
+    "h2" => false,
+    "h3" => false,
+    "h4" => false,
+    "h5" => false,
+    "h6" => false,
+    "head" => true,
+    "header" => false,
+    "hgroup" => false,
+    "hr" => false,
+    "html" => true,
+    "i" => false,
+    "iframe" => false,
+    "img" => false,
+    "input" => false,
+    "ins" => false,
+    "kbd" => false,
+    "keygen" => false,
+    "label" => false,
+    "legend" => false,
+    "li" => false,
+    "link" => true,
+    "main" => false,
+    "map" => false,
+    "mark" => false,
+    "marquee" => false,
+    "menu" => false,
+    "menuitem" => false,
+    "meta" => true,
+    "meter" => false,
+    "nav" => false,
+    "noembed" => true,
+    "noscript" => true,
+    "object" => false,
+    "ol" => false,
+    "optgroup" => false,
+    "option" => false,
+    "output" => false,
+    "p" => false,
+    "param" => true,
+    "picture" => true,
+    "pre" => false,
+    "progress" => false,
+    "q" => false,
+    "rp" => false,
+    "rt" => false,
+    "rtc" => false,
+    "ruby" => false,
+    "s" => false,
+    "samp" => false,
+    "script" => true,
+    "section" => false,
+    "select" => false,
+    "small" => false,
+    "source" => true,
+    "spacer" => false,
+    "span" => false,
+    "strike" => false,
+    "strong" => false,
+    "style" => true,
+    "sub" => false,
+    "summary" => false,
+    "sup" => false,
+    "table" => false,
+    "tbody" => false,
+    "td" => false,
+    "textarea" => false,
+    "tfoot" => false,
+    "th" => false,
+    "thead" => false,
+    "time" => false,
+    "title" => true,
+    "tr" => false,
+    "track" => true,
+    "tt" => false,
+    "u" => false,
+    "ul" => false,
+    "var" => false,
+    "video" => false,
+    "wbr" => false,
+    "xmp" => false,
+};
 
-fn init_dom_elements_map() -> &'static HashMap<&'static str, bool> {
-    let map = DOM_ELEMENTS.get_or_init(|| {
-        let mut m = HashMap::new();
-        m.insert("a", false);
-        m.insert("abbr", false);
-        m.insert("acronym", false);
-        m.insert("address", false);
-        m.insert("applet", false);
-        m.insert("area", false);
-        m.insert("article", false);
-        m.insert("aside", false);
-        m.insert("audio", false);
-        m.insert("b", false);
-        m.insert("base", true);
-        m.insert("bdi", false);
-        m.insert("bdo", false);
-        m.insert("big", false);
-        m.insert("blink", false);
-        m.insert("blockquote", false);
-        m.insert("body", false);
-        m.insert("br", false);
-        m.insert("button", false);
-        m.insert("canvas", false);
-        m.insert("caption", false);
-        m.insert("center", false);
-        m.insert("cite", false);
-        m.insert("code", false);
-        m.insert("col", true);
-        m.insert("colgroup", true);
-        m.insert("content", false);
-        m.insert("data", false);
-        m.insert("datalist", false);
-        m.insert("dd", false);
-        m.insert("del", false);
-        m.insert("details", false);
-        m.insert("dfn", false);
-        m.insert("dialog", false);
-        m.insert("dir", false);
-        m.insert("div", false);
-        m.insert("dl", false);
-        m.insert("dt", false);
-        m.insert("em", false);
-        m.insert("embed", false);
-        m.insert("fieldset", false);
-        m.insert("figcaption", false);
-        m.insert("figure", false);
-        m.insert("font", false);
-        m.insert("footer", false);
-        m.insert("form", false);
-        m.insert("frame", false);
-        m.insert("frameset", false);
-        m.insert("h1", false);
-        m.insert("h2", false);
-        m.insert("h3", false);
-        m.insert("h4", false);
-        m.insert("h5", false);
-        m.insert("h6", false);
-        m.insert("head", true);
-        m.insert("header", false);
-        m.insert("hgroup", false);
-        m.insert("hr", false);
-        m.insert("html", true);
-        m.insert("i", false);
-        m.insert("iframe", false);
-        m.insert("img", false);
-        m.insert("input", false);
-        m.insert("ins", false);
-        m.insert("kbd", false);
-        m.insert("keygen", false);
-        m.insert("label", false);
-        m.insert("legend", false);
-        m.insert("li", false);
-        m.insert("link", true);
-        m.insert("main", false);
-        m.insert("map", false);
-        m.insert("mark", false);
-        m.insert("marquee", false);
-        m.insert("menu", false);
-        m.insert("menuitem", false);
-        m.insert("meta", true);
-        m.insert("meter", false);
-        m.insert("nav", false);
-        m.insert("noembed", true);
-        m.insert("noscript", true);
-        m.insert("object", false);
-        m.insert("ol", false);
-        m.insert("optgroup", false);
-        m.insert("option", false);
-        m.insert("output", false);
-        m.insert("p", false);
-        m.insert("param", true);
-        m.insert("picture", true);
-        m.insert("pre", false);
-        m.insert("progress", false);
-        m.insert("q", false);
-        m.insert("rp", false);
-        m.insert("rt", false);
-        m.insert("rtc", false);
-        m.insert("ruby", false);
-        m.insert("s", false);
-        m.insert("samp", false);
-        m.insert("script", true);
-        m.insert("section", false);
-        m.insert("select", false);
-        m.insert("small", false);
-        m.insert("source", true);
-        m.insert("spacer", false);
-        m.insert("span", false);
-        m.insert("strike", false);
-        m.insert("strong", false);
-        m.insert("style", true);
-        m.insert("sub", false);
-        m.insert("summary", false);
-        m.insert("sup", false);
-        m.insert("table", false);
-        m.insert("tbody", false);
-        m.insert("td", false);
-        m.insert("textarea", false);
-        m.insert("tfoot", false);
-        m.insert("th", false);
-        m.insert("thead", false);
-        m.insert("time", false);
-        m.insert("title", true);
-        m.insert("tr", false);
-        m.insert("track", true);
-        m.insert("tt", false);
-        m.insert("u", false);
-        m.insert("ul", false);
-        m.insert("var", false);
-        m.insert("video", false);
-        m.insert("wbr", false);
-        m.insert("xmp", false);
-        m
-    });
-
-    map
-}
-
-pub fn entries() -> &'static HashMap<&'static str, bool> {
-    init_dom_elements_map()
+pub fn entries() -> HashMap<&'static str, bool> {
+    DOM_ELEMENTS.entries().map(|(k, v)| (*k, *v)).collect()
 }
 
 pub fn for_each(mut callback: impl FnMut(&'static str, bool)) {
-    init_dom_elements_map()
-        .iter()
-        .for_each(|(k, v)| callback(k, *v));
+    DOM_ELEMENTS.into_iter().for_each(|(k, v)| callback(k, *v));
 }
 
 pub fn get(name: &str) -> Option<bool> {
-    init_dom_elements_map().get(name).copied()
+    DOM_ELEMENTS.get(name).copied()
 }
 
 pub fn has(name: &str) -> bool {
-    init_dom_elements_map().contains_key(name)
+    DOM_ELEMENTS.contains_key(name)
 }
 
 pub fn keys() -> impl Iterator<Item = &'static str> {
-    init_dom_elements_map().keys().copied()
+    DOM_ELEMENTS.keys().copied()
 }
 
 pub fn values() -> impl Iterator<Item = bool> {
-    init_dom_elements_map().values().copied()
+    DOM_ELEMENTS.values().copied()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
from: https://github.com/oxc-project/aria-query/pull/3#discussion_r1436662016

use [phf](https://github.com/rust-phf/rust-phf) to define a static map instead of oncelock. I/O is not changed, so the output type does not depend on the `phf`